### PR TITLE
small change to make presigned media urls on cdn work

### DIFF
--- a/banmarchive/settings/production.py
+++ b/banmarchive/settings/production.py
@@ -9,6 +9,7 @@ ALLOWED_HOSTS = [urlparse(BASE_URL).netloc]
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
+AWS_S3_ADDRESSING_STYLE = 'virtual'
 AWS_S3_REGION_NAME = os.getenv('AWS_S3_REGION_NAME')
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
 AWS_S3_ENDPOINT_URL = os.getenv('AWS_S3_ENDPOINT_URL')


### PR DESCRIPTION
We'll also need to update MEDIA_URL in the app settings to point to the cdn-enabled spaces url.

As a reminder, the reason using the cdn is particuarly important is that it runs over cloudflare, so (unlike the IP of a DO spaces bucket) if an ISP were to carelessly IP-block it (as virgin media currently are), it would also break the entire internet. So they'd actually fix it.

From: https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html

> AWS_S3_ADDRESSING_STYLE (optional: default is None)
>     Possible values virtual and path.

From https://docs.digitalocean.com/products/spaces/how-to/enable-cdn/
> You can also use presigned URLs with the Spaces CDN. To do so, configure your SDK or S3 tool to use the non-CDN endpoint, generate a presigned URL for a GetObject request, then modify the hostname in the URL to be the CDN hostname (<space-name>.<region>.cdn.digitaloceanspaces.com, unless the Space uses a custom hostname).