### PR TITLE
fix: crash when archive has publications with no issues

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -49,7 +49,7 @@ class HomePage(Page):
     def issue_sample(self):
         return (
             p.random_issue()
-            for p in random_model(self.publications, count=4)
+            for p in random_model(self.publications.live().filter(numchild__gt=0), count=4)
         )
 
 

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -19,7 +19,9 @@
   <section class="container-fluid showcase px-lg-5">
     <div class="card-grid card-grid-oneline mb-4 mb-lg-5">
       {% for issue in self.issue_sample %}
-      {% publication_card issue %}
+        {% if issue %}
+          {% publication_card issue %}
+        {% endif %}
       {% endfor %}
     </div>
   </section>

--- a/publications/models.py
+++ b/publications/models.py
@@ -117,8 +117,8 @@ class Publication(AbstractArchiveItem):
     @django_cached('publications.models.Publication.random_issue', lambda self: self.id)
     def random_issue(self):
         for _ in range(5):
-            candidate = random_model(self.issues)
-            if candidate.specific.get_thumbnail_document() is not None:
+            candidate = random_model(self.issues.live())
+            if candidate is not None and candidate.specific.get_thumbnail_document() is not None:
                 return candidate
 
         return candidate


### PR DESCRIPTION
Archive was crashing on the 'issue carousel' on the homepage when there were publications with no issues.
This adds some safety checks to ensure we only try to render publications on the carousel that actually have issues